### PR TITLE
no need to distribute lots of waf stuff in smith source dist

### DIFF
--- a/wscript
+++ b/wscript
@@ -360,7 +360,7 @@ def build(bld):
 
 def dist(ctx) :
     #import pdb; pdb.set_trace()
-    includes = ['docs/', 'README*', 'smithlib/', 'smith-playground/', 'waflib/', 'wscript', 'mywaflite', 'waf-light', 'TODO', 'Changelog', 'bash_completion_smith']
-    excludes = ['**/*~', '**/*.sw*', '**/*.pyc', '**/*.pyo', '**/*.bak', '**/.lock-w*', '**/.waf*', '**/buildlinux2/', 'docs/book', 'docs/slides', 'docs/sphinx', 'docs/gfx']
+    includes = ['docs/smith/', 'README*', 'smithlib/', 'smith-playground/', 'waflib/', 'wscript', 'mywaflite', 'waf-light', 'TODO', 'Changelog', 'bash_completion_smith']
+    excludes = ['**/*~', '**/*.sw*', '**/*.pyc', '**/*.pyo', '**/*.bak', '**/.lock-w*', '**/.waf*', '**/buildlinux2/']
     ctx.files = ctx.path.ant_glob(incl=includes, excl=excludes)
     ctx.algo = 'tar.gz'

--- a/wscript
+++ b/wscript
@@ -360,7 +360,7 @@ def build(bld):
 
 def dist(ctx) :
     #import pdb; pdb.set_trace()
-    includes = ['demos/', 'docs/', 'playground/', 'README*', 'smithlib/', 'smith-playground/', 'tests/', 'utils/', 'waflib/', 'wscript', 'mywaflite', 'waf-light', 'TODO', 'DEVEL', 'Changelog', 'bash_completion_smith', 'configure', 'Makefile']
-    excludes = ['**/*~', '**/*.sw*', '**/*.pyc', '**/*.pyo', '**/*.bak', '**/.lock-w*', '**/.waf*', '**/buildlinux2/']
+    includes = ['docs/', 'README*', 'smithlib/', 'smith-playground/', 'waflib/', 'wscript', 'mywaflite', 'waf-light', 'TODO', 'Changelog', 'bash_completion_smith']
+    excludes = ['**/*~', '**/*.sw*', '**/*.pyc', '**/*.pyo', '**/*.bak', '**/.lock-w*', '**/.waf*', '**/buildlinux2/', 'docs/book', 'docs/slides', 'docs/sphinx', 'docs/gfx']
     ctx.files = ctx.path.ant_glob(incl=includes, excl=excludes)
     ctx.algo = 'tar.gz'


### PR DESCRIPTION
imho there is no need for lots of the waf stuff to be in the source tar that you can create using ./waf-light dist. That source tar is what I'd use for making the package to go into Debian.