### PR TITLE
Add Dockerfile to produce a full smith & tools docker image for CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*
+!bash_completion_smith
+!docker
+!MANIFEST.in
+!setup.py
+!smith.py
+!smithlib
+!waflib
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,196 @@
+# Set up basic runtime environment
+ARG ubuntuImage='ubuntu:20.04'
+ARG type=build-agent
+
+FROM ${ubuntuImage} AS base
+USER root
+ENV DEBIAN_FRONTEND='noninteractive' TZ='UTC'
+COPY docker/no-cache  /etc/apt/apt.conf.d/00_no-cache
+RUN apt-get update && apt-get install -y \
+      ca-certificates \
+      git \
+      gpg \
+      locales \
+      libcairo2 \
+      libfreetype6 \
+      libglib2.0-0 \
+      libgirepository-1.0-1 \
+      libicu66 \
+      libmono-system-web4.0-cil \
+      libmono-system-windows-forms4.0-cil \
+      mono-runtime \
+      python3-brotli \
+      python3-fs \
+      python3-gi \
+      python3-icu \
+      python3-lz4 \
+      python3-odf \
+      python3-pkg-resources \
+      python3-reportlab \
+      python3-scipy \
+      && \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG='en_US.UTF-8'
+    
+
+# Set up basic build tooling environment
+FROM base AS build
+ENV PATH=$PATH:/root/.local/bin
+RUN apt-get install -y \
+      build-essential \
+      cmake \
+      gcovr \
+      gobject-introspection \
+      gtk-doc-tools \
+      libcairo2-dev \
+      libfreetype-dev \
+      libglib2.0-dev \
+      libgirepository1.0-dev \
+      libicu-dev \
+      libpython3-dev \
+      libtool \
+      mono-mcs \
+      ninja-build \
+      python3-pip \
+      pkg-config \
+      ragel \
+      &&\
+    pip install --user meson
+
+
+# Grab the PPA keys for later use.
+FROM ${ubuntuImage} AS ppa-keys
+USER root
+RUN apt-get update && apt-get install -y dirmngr gnupg &&\
+    apt-key \
+        --keyring /ppa-archives-keyring.gpg \
+      adv \
+        --keyserver keyserver.ubuntu.com \
+        --recv-keys 904F67626F1CF535 5DF1CE288B1A27EA
+
+
+# Build Glyph layout engines
+FROM build AS engines-src
+WORKDIR /src/graphite
+RUN git clone --depth 1 https://github.com/silnrsi/graphite.git . &&\
+    cmake -G Ninja -B build \
+      -DGRAPHITE2_COMPARE_RENDERER:BOOL=OFF \
+      -DGRAPHITE2_NTRACING:BOOL=OFF \
+      &&\
+    cmake --build build && cmake --install build;
+WORKDIR /src/harffbuzz
+RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git . &&\
+    meson build \
+        --buildtype=debugoptimized \
+        --auto-features=enabled \
+        --wrap-mode=nodownload \
+        -Db_coverage=true \
+        -Dchafa=disabled \
+        -Dexperimental_api=true\
+        -Dgraphite=enabled \
+        &&\
+    ninja -C build && ninja install -C build;
+
+
+# Build graphite compiler
+FROM build AS grcompiler-src
+WORKDIR /src/grcompiler
+RUN git clone --depth 1 https://github.com/silnrsi/grcompiler.git . &&\
+    cmake -G Ninja -B build && cmake --build build && cmake --install build;
+
+
+# Build OTS Sanitizer
+FROM build AS ots-src
+WORKDIR /src/ots
+RUN pip install 'git+https://github.com/googlefonts/ots-python.git@main#egg=opentype-sanitizer' &&\
+    git clone --depth 1 --recurse-submodules https://github.com/khaledhosny/ots.git . &&\
+    meson build && ninja -C build && ninja install -C build
+
+
+# Build Font validator
+FROM build AS fontval
+WORKDIR /src/fontval
+RUN git clone --depth 1 https://github.com/HinTak/Font-Validator.git . &&\
+    make && make gendoc &&\
+    cp bin/*.exe bin/*.dll* bin/*.xsl /usr/local/bin
+
+
+# Python components
+FROM build AS python3-dependencies
+RUN pip install \
+      'git+https://github.com/googlei18n/compreffor' \
+      'git+https://github.com/googlefonts/fontbakery' \
+      'git+https://github.com/fonttools/fonttools' \
+      'git+https://github.com/googlefonts/GlyphsLib' \
+      'git+https://github.com/rosettatype/hyperglot' \
+      'git+https://github.com/googlefonts/pyfontaine' \
+      'git+https://github.com/silnrsi/palaso-python' \
+      'git+https://github.com/LettError/MutatorMath' \
+      'git+https://github.com/silnrsi/pysilfont' \
+      'git+https://github.com/googlei18n/ufo2ft'
+WORKDIR smith
+COPY . ./
+RUN pip install . 
+
+
+# Final minimal smith font build system runtime CI systems
+FROM base AS build-agent
+ARG codename=focal
+LABEL org.opencontainers.image.authors="tim_eves@sil.org, nicolas_spaligner@sil.org" \
+      org.opencontainers.image.title="smith-font" \
+      org.opencontainers.image.documentation="https://github.com/silnrsi/smith/blob/master/docs/smith/manual.asc" \
+      org.opencontainers.image.description="Smith font build environment" \
+      org.opencontainers.image.source="https://github.com/silnrsi/smith" \
+      org.opencontainers.image.vendor="SIL International"
+COPY docker/sources.list.d/*-${codename}.list /etc/apt/sources.list.d/
+COPY --from=ppa-keys /ppa-archives-keyring.gpg /etc/apt/trusted.gpg.d/
+RUN apt-get update && apt-get install -y \
+      fontforge-nox \
+      libaa-bin \
+      libfont-ttf-scripts-perl \
+      libqt5gui5-gles \
+      libjson-perl \
+      libtext-csv-perl \
+      nsis \
+      pandoc \
+      python3-fontforge \
+      sile \
+      texlive-xetex \
+      ttfautohint \
+      wamerican \
+      wbritish \
+      xsltproc \
+      xz-utils \
+      &&\
+    sile -e 'installPackage("fontproof");os.exit()'
+COPY docker/validator-shims /usr/local/bin/
+COPY --from=fontval /usr/local /usr/local
+COPY --from=grcompiler-src /usr/local /usr/local
+COPY --from=ots-src /usr/local /usr/local
+COPY --from=python3-dependencies /usr/local /usr/local
+COPY --from=engines-src /usr/local /usr/local
+
+
+# Add in some user facing tools for interactive use.
+FROM build-agent AS interactive
+COPY bash_completion_smith /etc/bash_completion.d/
+RUN apt-get update && apt-get install -y bash-completion less nano ncdu sudo &&\
+    useradd -md /build builder &&\
+    echo 'builder ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+VOLUME /build
+USER builder
+CMD ["/bin/bash"]
+
+
+# Final clean up regardless of which type was chosen.
+FROM ${type} AS final
+ARG codename=focal
+LABEL org.opencontainers.image.authors="tim_eves@sil.org, nicolas_spaligner@sil.org" \
+      org.opencontainers.image.title="smith-font" \
+      org.opencontainers.image.documentation="https://github.com/silnrsi/smith/blob/master/docs/smith/manual.asc" \
+      org.opencontainers.image.description="Smith font build environment" \
+      org.opencontainers.image.source="https://github.com/silnrsi/smith" \
+      org.opencontainers.image.vendor="SIL International"
+RUN apt-get autoremove --purge &&\
+    rm /var/lib/apt/lists/* /var/lib/apt/lists/partial/*; true 
+

--- a/README.md
+++ b/README.md
@@ -1,21 +1,78 @@
 ## Smith
 
-smith is a Python-based framework for building, testing and maintaining WSI (Writing Systems Implementation) components such as fonts and keyboards. It is based on waf.
-Smith orchestrates and integrates various tools and utilities to make a standards-based open font design and production workflow easier to manage.
+smith is a Python-based framework for building, testing and maintaining WSI
+(Writing Systems Implementation) components such as fonts and keyboards. It is
+based on waf.
+Smith orchestrates and integrates various tools and utilities to make a
+standards-based open font design and production workflow easier to manage.
 
-Building a font involves numerous steps and various programs, which, if done by hand, would be prohibitively slow. Even working out what those steps are can take a lot of work. Smith uses a dedicated file at the root of the project (the file is python-based) to allow the user to describe how to build the font. By chaining the different build steps intelligently, smith reduces build times to seconds rather than minutes or hours, and makes build, test, fix, repeat cycles very manageable. By making these processes repeatable, including for a number of fonts at the same time, your project can be shared with others simply, or - better yet - it can be included in a CI (Continuous Integration) system. This allows for fonts (and their various source formats) to truly be libre/open source software and developed with open and collaborative methodologies.
+Building a font involves numerous steps and various programs, which, if done by
+hand, would be prohibitively slow. Even working out what those steps are can
+take a lot of work. Smith uses a dedicated file at the root of the project (the
+file is python-based) to allow the user to describe how to build the font. By
+chaining the different build steps intelligently, smith reduces build times to
+seconds rather than minutes or hours, and makes build, test, fix, repeat cycles
+very manageable. By making these processes repeatable, including for a number
+of fonts at the same time, your project can be shared with others simply, or -
+better yet - it can be included in a CI (Continuous Integration) system. This
+allows for fonts (and their various source formats) to truly be libre/open
+source software and developed with open and collaborative methodologies.
 
-Smith is _Copyright (c) 2011-2018 SIL International (www.sil.org)_   
+Smith is _Copyright (c) 2011-2018 SIL International (www.sil.org)_
 and is released under _the BSD license_.
 
 ### Documentation
 
-The manual (including a step-by-step tutorial) is in [docs/smith](docs/smith/manual.asc).
+The manual (including a step-by-step tutorial) is in
+[docs/smith](docs/smith/manual.asc).
 (to regenerate:  cd docs/smith/ && ./build-docs.sh)
 
 
 ### Installation
 
-The current VM (Virtual Machine) installation files (using vagrant) are in [vm-install](vm-install).  
-These files make it easier to use smith (and its various components) on macOS, Windows or Ubuntu.  
-Simply copy the files to the root of your project and run ``vagrant up``.
+The standard `pip install .` will install just the smith packages and commands,
+but will not install all the other font tooling which smith will search for
+when `smith configure` is run.  For complete font build envrionments there are
+two ready made options below, depending on interactive or CI use cases:
+
+#### Vagrant support VM images
+The current VM (Virtual Machine) installation files (using vagrant) are in
+[vm-install](vm-install).  These files make it easier to use smith (and its
+various components) on macOS,
+Windows or Ubuntu.  Simply copy the files to the root of your project and
+run ``vagrant up``.
+
+#### Docker image
+
+The primary purpose of the Docker image is to provide a base for CI systems to
+have a complete smith build environment. However you can also use it locally as
+is, simply by running:
+  `docker run --rm -it -v $WORKSPACE:/build smith:latest`
+This will fetch and use the latest smith docker image from docker hub and run
+it with the absoulte path (or docker volume) `$WORKSPACE` mapped to `/build`
+inside, and an interactive bash session (the `-it` options).  The `--rm` makes
+the container ephemeral.
+
+If you wish to build your own image you will need to run `docker build .` in
+the top-level source dir and this will download and build the latest
+dependencies for the smith font build enviroment and install the smith python
+packages from the source dir.
+The Dockerfile can take the following build args:
+  `ubuntuImage`: (default: "ubuntu:20.04")
+     The base image to build on.  This does not need to be an official Ubuntu
+     image, but can be an image built on Ubuntu. e.g. This is how the TeamCity
+     build agent image is generated.
+  `type`: (default: "build-agent")
+     This can be either `interactive` or `build-agent`. If `interactive` is 
+     chosen it will install a `builder` user who has pasword-less sudo, and the
+     `less`, `bash_completion`, and `nano` packages. 
+Thus to build the interactive image run:
+```
+$> docker build --build-arg=type=build-agent .
+```
+Our TeamCity build agent is built like so:
+```
+$> docker --build-arg=ubuntuImage="jetbrains/teamcity-agent" .
+```
+We recommend using BuildKit, as it halves the build time with this Dockerfile
+

--- a/docker/no-cache
+++ b/docker/no-cache
@@ -1,0 +1,4 @@
+APT::Install-Recommends "0";
+APT::Install-Suggests "0";
+Dir::Cache::pkgcache "";
+Dir::Cache::srcpkgcache "";

--- a/docker/sources.list.d/sile-typesetter-ubuntu-sile-bionic.list
+++ b/docker/sources.list.d/sile-typesetter-ubuntu-sile-bionic.list
@@ -1,0 +1,1 @@
+deb http://ppa.launchpad.net/sile-typesetter/sile/ubuntu bionic main

--- a/docker/sources.list.d/sile-typesetter-ubuntu-sile-focal.list
+++ b/docker/sources.list.d/sile-typesetter-ubuntu-sile-focal.list
@@ -1,0 +1,1 @@
+deb http://ppa.launchpad.net/sile-typesetter/sile/ubuntu focal main

--- a/docker/sources.list.d/smith-py3-ubuntu-smith-bionic.list
+++ b/docker/sources.list.d/smith-py3-ubuntu-smith-bionic.list
@@ -1,0 +1,1 @@
+deb http://ppa.launchpad.net/silnrsi/smith-py3/ubuntu bionic main

--- a/docker/sources.list.d/smith-py3-ubuntu-smith-focal.list
+++ b/docker/sources.list.d/smith-py3-ubuntu-smith-focal.list
@@ -1,0 +1,1 @@
+deb http://ppa.launchpad.net/silnrsi/smith-py3/ubuntu focal main

--- a/docker/validator-shims/FontValidator
+++ b/docker/validator-shims/FontValidator
@@ -1,0 +1,2 @@
+#!/bin/sh
+mono /usr/local/bin/FontValidator.exe "$@"

--- a/docker/validator-shims/fontval
+++ b/docker/validator-shims/fontval
@@ -1,0 +1,2 @@
+#!/bin/sh
+mono /usr/local/bin/FontValidator.exe -quiet -all-tables -report-in-font-dir -file "$1"


### PR DESCRIPTION
Suitable for a Continuous Integeration system, either as a base or an additional layer. Can optionally be built for interactive use, which is useful for clean install testing of smith by developers.